### PR TITLE
Check that directory is a git repository

### DIFF
--- a/build/systems/git/index.js
+++ b/build/systems/git/index.js
@@ -82,7 +82,12 @@ exports.clone = function(url, directory) {
  */
 
 exports.associate = function(directory, url) {
-  return utils.execute(directory, "remote add resin " + url);
+  return utils.isGitRepository(directory).then(function(isGitRepository) {
+    if (!isGitRepository) {
+      throw new Error("Not a git repository: " + directory);
+    }
+    return utils.execute(directory, "remote add resin " + url);
+  });
 };
 
 
@@ -101,10 +106,15 @@ exports.associate = function(directory, url) {
  */
 
 exports.getApplicationName = function(directory) {
-  return utils.getRemote(directory).then(function(remoteUrl) {
-    if (remoteUrl == null) {
-      return;
+  return utils.isGitRepository(directory).then(function(isGitRepository) {
+    if (!isGitRepository) {
+      throw new Error("Not a git repository: " + directory);
     }
-    return path.basename(remoteUrl, '.git');
+    return utils.getRemote(directory).then(function(remoteUrl) {
+      if (remoteUrl == null) {
+        return;
+      }
+      return path.basename(remoteUrl, '.git');
+    });
   });
 };

--- a/build/systems/git/utils.js
+++ b/build/systems/git/utils.js
@@ -63,6 +63,29 @@ exports.execute = function(directory, command) {
 
 
 /**
+ * @summary Check if a directory is a git repository
+ * @function
+ * @protected
+ *
+ * @param {String} directory - directory
+ * @returns {Promise<Boolean>} is a git repository
+ *
+ * @example
+ * utils.isGitRepository('foo/bar').then (isGitRepository) ->
+ * 	if isGitRepository
+ * 		console.log('Is is a git repository')
+ */
+
+exports.isGitRepository = function(directory) {
+  return Promise.fromNode(function(callback) {
+    return gitwrap.create(directory).isGitRepository(function(isGitRepository) {
+      return callback(null, isGitRepository);
+    });
+  });
+};
+
+
+/**
  * @summary Get git resin remote from a repository
  * @function
  * @protected

--- a/lib/systems/git/index.coffee
+++ b/lib/systems/git/index.coffee
@@ -71,7 +71,11 @@ exports.clone = (url, directory) ->
 # vcs.associate('foo/bar', 'jviotti@git.resin.io:jviotti/foobar.git')
 ###
 exports.associate = (directory, url) ->
-	utils.execute(directory, "remote add resin #{url}")
+	utils.isGitRepository(directory).then (isGitRepository) ->
+		if not isGitRepository
+			throw new Error("Not a git repository: #{directory}")
+
+		utils.execute(directory, "remote add resin #{url}")
 
 ###*
 # @summary Get the associated application name from a repository
@@ -87,6 +91,10 @@ exports.associate = (directory, url) ->
 # 		console.log(applicationName)
 ###
 exports.getApplicationName = (directory) ->
-	utils.getRemote(directory).then (remoteUrl) ->
-		return if not remoteUrl?
-		return path.basename(remoteUrl, '.git')
+	utils.isGitRepository(directory).then (isGitRepository) ->
+		if not isGitRepository
+			throw new Error("Not a git repository: #{directory}")
+
+		utils.getRemote(directory).then (remoteUrl) ->
+			return if not remoteUrl?
+			return path.basename(remoteUrl, '.git')

--- a/lib/systems/git/utils.coffee
+++ b/lib/systems/git/utils.coffee
@@ -49,6 +49,24 @@ exports.execute = (directory, command) ->
 			return callback(null, stdout.trim() or undefined)
 
 ###*
+# @summary Check if a directory is a git repository
+# @function
+# @protected
+#
+# @param {String} directory - directory
+# @returns {Promise<Boolean>} is a git repository
+#
+# @example
+# utils.isGitRepository('foo/bar').then (isGitRepository) ->
+# 	if isGitRepository
+# 		console.log('Is is a git repository')
+###
+exports.isGitRepository = (directory) ->
+	Promise.fromNode (callback) ->
+		gitwrap.create(directory).isGitRepository (isGitRepository) ->
+			return callback(null, isGitRepository)
+
+###*
 # @summary Get git resin remote from a repository
 # @function
 # @protected

--- a/tests/systems/git/index.spec.coffee
+++ b/tests/systems/git/index.spec.coffee
@@ -5,43 +5,80 @@ utils = require('../../../lib/systems/git/utils')
 
 describe 'Git:', ->
 
+	describe '.associate()', ->
+
+		describe 'given the directory is not a git repository', ->
+
+			beforeEach ->
+				@utilsIsGitRepository = m.sinon.stub(utils, 'isGitRepository')
+				@utilsIsGitRepository.returns(Promise.resolve(false))
+
+			afterEach ->
+				@utilsIsGitRepository.restore()
+
+			it 'should be rejected with an error', ->
+				promise = git.associate('foo/bar', 'jviotti@git.resin.io:jviotti/foobar.git')
+				m.chai.expect(promise).to.be.rejectedWith('Not a git repository: foo/bar')
+
 	describe '.getApplicationName()', ->
 
-		describe 'given a valid resin git remote', ->
+		describe 'given the directory is not a git repository', ->
 
 			beforeEach ->
-				@utilsGetRemote = m.sinon.stub(utils, 'getRemote')
-				@utilsGetRemote.returns(Promise.resolve('jviotti@git.resin.io:jviotti/foobar.git'))
+				@utilsIsGitRepository = m.sinon.stub(utils, 'isGitRepository')
+				@utilsIsGitRepository.returns(Promise.resolve(false))
 
 			afterEach ->
-				@utilsGetRemote.restore()
+				@utilsIsGitRepository.restore()
 
-			it 'should eventually equal the application name', ->
+			it 'should be rejected with an error', ->
 				promise = git.getApplicationName('foo/bar')
-				m.chai.expect(promise).to.eventually.equal('foobar')
+				m.chai.expect(promise).to.be.rejectedWith('Not a git repository: foo/bar')
 
-		describe 'given no resin git remote', ->
+		describe 'given the directory is a git repository', ->
 
 			beforeEach ->
-				@utilsGetRemote = m.sinon.stub(utils, 'getRemote')
-				@utilsGetRemote.returns(Promise.resolve(undefined))
+				@utilsIsGitRepository = m.sinon.stub(utils, 'isGitRepository')
+				@utilsIsGitRepository.returns(Promise.resolve(true))
 
 			afterEach ->
-				@utilsGetRemote.restore()
+				@utilsIsGitRepository.restore()
 
-			it 'should eventually be undefined', ->
-				promise = git.getApplicationName('foo/bar')
-				m.chai.expect(promise).to.eventually.be.undefined
+			describe 'given a valid resin git remote', ->
 
-		describe 'given an error getting the remote', ->
+				beforeEach ->
+					@utilsGetRemote = m.sinon.stub(utils, 'getRemote')
+					@utilsGetRemote.returns(Promise.resolve('jviotti@git.resin.io:jviotti/foobar.git'))
 
-			beforeEach ->
-				@utilsGetRemote = m.sinon.stub(utils, 'getRemote')
-				@utilsGetRemote.returns(Promise.reject(new Error('git error')))
+				afterEach ->
+					@utilsGetRemote.restore()
 
-			afterEach ->
-				@utilsGetRemote.restore()
+				it 'should eventually equal the application name', ->
+					promise = git.getApplicationName('foo/bar')
+					m.chai.expect(promise).to.eventually.equal('foobar')
 
-			it 'should be rejected with the error', ->
-				promise = git.getApplicationName('foo/bar')
-				m.chai.expect(promise).to.be.rejectedWith('git error')
+			describe 'given no resin git remote', ->
+
+				beforeEach ->
+					@utilsGetRemote = m.sinon.stub(utils, 'getRemote')
+					@utilsGetRemote.returns(Promise.resolve(undefined))
+
+				afterEach ->
+					@utilsGetRemote.restore()
+
+				it 'should eventually be undefined', ->
+					promise = git.getApplicationName('foo/bar')
+					m.chai.expect(promise).to.eventually.be.undefined
+
+			describe 'given an error getting the remote', ->
+
+				beforeEach ->
+					@utilsGetRemote = m.sinon.stub(utils, 'getRemote')
+					@utilsGetRemote.returns(Promise.reject(new Error('git error')))
+
+				afterEach ->
+					@utilsGetRemote.restore()
+
+				it 'should be rejected with the error', ->
+					promise = git.getApplicationName('foo/bar')
+					m.chai.expect(promise).to.be.rejectedWith('git error')

--- a/tests/systems/git/utils.spec.coffee
+++ b/tests/systems/git/utils.spec.coffee
@@ -95,3 +95,35 @@ describe 'Utils:', ->
 			it 'should be rejected with the error message', ->
 				promise = utils.execute('foo/bar', 'command')
 				m.chai.expect(promise).to.be.rejectedWith('git error')
+
+	describe '.isGitRepository()', ->
+
+		describe 'given the directory is a git repository', ->
+
+			beforeEach ->
+				@gitwrapCreateStub = m.sinon.stub(gitwrap, 'create')
+				@gitwrapCreateStub.returns
+					isGitRepository: (callback) ->
+						return callback(true)
+
+			afterEach ->
+				@gitwrapCreateStub.restore()
+
+			it 'should eventually equal true', ->
+				promise = utils.isGitRepository('foo/bar')
+				m.chai.expect(promise).to.eventually.be.true
+
+		describe 'given the directory is not a git repository', ->
+
+			beforeEach ->
+				@gitwrapCreateStub = m.sinon.stub(gitwrap, 'create')
+				@gitwrapCreateStub.returns
+					isGitRepository: (callback) ->
+						return callback(false)
+
+			afterEach ->
+				@gitwrapCreateStub.restore()
+
+			it 'should eventually equal false', ->
+				promise = utils.isGitRepository('foo/bar')
+				m.chai.expect(promise).to.eventually.be.false


### PR DESCRIPTION
Perform this check in the following commands which rely on the passed
directory to be a git repository:
- `associate()`.
- `getApplicationName()`.

Fixes: https://github.com/resin-io/resin-cli/issues/196
